### PR TITLE
Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Understanding the correspondence between cellular identity and perturbation resp
 
 3. For a given perturbation, which cell states respond strongly via each response program?
 
-    For one perturbation $p$, given a response program $q$ of interest, the basal state $\vec{z}_n^\text{(basal)}$ can be queried by the learned perturbation key $\vec{\kappa}_{pq}$. This is a key question that CellCap addresses: the correspondence between basal cell state and perturbation response.
+    For one perturbation $p$, given a response program $q$ of interest, the basal state $z_{nk}^\text{(basal)}$ can be queried by the learned perturbation key $\kappa_{pqk}$. This is a key question that CellCap addresses: the correspondence between basal cell state and perturbation response.
 
 4. What is the response amplitude of each response program in each basal cell state?
 

--- a/README.md
+++ b/README.md
@@ -1,44 +1,44 @@
 CellCap
 =======
 
-CellCap is a variational autoencoder for modeling interpretable correspondence between cell state and perturbation response in single-cell data.
+CellCap is a generative model of scRNA-seq perturbation data which emphasizes interpretability. CellCap explicitly models the correspondence between each cell's basal state and the measured perturbation response, and learns how to explain cellular response in terms of weighted sums of a succinct set of response programs.
 
 Key concepts of CellCap
 ----------------------
-To understand such correspondence between cell state and perturbation response , CellCap was built with several explainable components:
+To understand the correspondence between basal cell state and perturbation response, the CellCap model was built with several interpretable components:
 
-![alt text](https://github.com/broadinstitute/CellCap/blob/main/docs/source/_static/design/Figure1.jpg?raw=false)
+![Fig.1a-b](https://github.com/broadinstitute/CellCap/blob/main/docs/source/_static/design/Figure1.jpg?raw=false)
 
-1. Basal state z<sub>nk</sub><sup>(basal)</sup>: basal state z<sub>nk</sub><sup>(basal)</sup> can be understood as cell state in latent space where only intrinsic
-cellular identity is preserved.
+1. Basal state $z_{nk}^\text{(basal)}$: this basal state of each cell $n$ can be understood as the pre-perturbation cell state in latent space $k$, where only intrinsic cellular variations are preserved. This basal state does not contain information about the applied perturbation or other covariate information (e.g. batch, donor, ...).
 
-2. Responsse program w<sub>qk</sub>: each response program p has its latent representation w<sub>k</sub> that has the same dimension as
-basal state z<sup>(basal)</sup>, and it explains the transcriptional activation or deactivation after perturbation.
+2. Response programs $w_{qk}$: each response program $q$ has a latent representation $\vec{w}_k$ that explains the transcriptional activation or deactivation of sets of genes in response to a perturbation.
 
-3. Perturbation key $\kappa$<sub>pqk</sub>: matching a key $\kappa$<sub>qk</sub> of perturbation p with a basal state z<sup>(basal)</sup> through attention mechanism is used to establish the correspondence between cell state and perturbation response. The output attention score $\beta$<sub>nq</sub> further represents the relevance of each basal state z<sup>(basal)</sup> to a response program q.
+3. Attention mechanism: shown in the blue rectangle in panel (a), a multi-head, scaled dot-product attention mechanism is used to model the correspondence between a basal cell state $z_{nk}^\text{(basal)}$ and perturbation responses $w_{qk}$. CellCap learns a set of key vectors $\kappa_{pqk}$ to capture this correspondence. The attention weights $\beta_{nq}$ represent the relevance of each response program $q$ to each basal cell state $z_{nk}^\text{(basal)}$.
 
-4. Program relevance H<sub>pq</sub>: similar to attention score $\beta$<sub>nq</sub> telling the relevance of each basal state z<sup>(basal)</sup> to a response program q, H<sub>q</sub> presents the relevance of a perturbation condition p to a response program q.
+4. Program relevance $H_{pq}$: a weight matrix that captures the relevance of response program $q$ to perturbation condition $p$. Bayesian automatic relevance determination is used by the model to keep this matrix sparse and interpretable.
 
 Downstream analyses with CellCap
 --------------------------------
 
-Understanding the correspondence between cellular identity and perturbation response would facilitate multiple
-biological investigations. We list a few suggested questions here, and users can use explainable components in CellCap
-to address them.
+Understanding the correspondence between cellular identity and perturbation response can help answer many biological questions. We list a few suggested questions here which can be answered using the key concepts of CellCap above.
 
-![alt text](https://github.com/broadinstitute/CellCap/blob/main/docs/source/_static/design/Figure2.jpg?raw=false)
+![Fig.1c-f](https://github.com/broadinstitute/CellCap/blob/main/docs/source/_static/design/Figure2.jpg?raw=false)
 
-1. Do perturbations behave similarly or differently: Use of H<sub>pq</sub> alone could describe a general relationship between any two perturbations. The same question can be asked again under a specific cellular context. Combining $\beta$<sub>nq</sub> and H<sub>pq</sub> can be used to understand if different perturbations cause similar cellular responses in given a cell population.
+1. How do perturbations relate to each other?
 
-2. What transcriptional responses can a perturbation induce: Each perturbation program q aims to reveal a set of genes that are concurrently activated or deactivated in perturbed cells. This can be done by forwarding w<sub>qk</sub> through the linear decoder.
+    General relationships are captured by the learned program relevance matrix $H_{pq}$. Additionally, the per-cell response matrix $h_{nq}$ can be used to understand whether different perturbations cause similar responses in given a cell population.
 
-3. Is a certain transcriptional response posed by a perturbation is cell-state specific: given a response program q
-of interest, basal state z<sub>nk</sub><sup>(basal)</sup> can be sorted by matching perturbation key $\kappa$<sub>pqk</sub>. This is the key question CellCap
-tries to address: the correspondence between cell state and perturbation response.
+2. What are the transcriptional response programs that we see in a dataset?
 
-4. How large is this transcriptional response in this cell state: given a perturbed cell that was treated with a
-perturbation p, CellCap first infers its basal state z<sup>(basal)</sup>. Then, CellCap infers response amplitude $\beta$<sub>q</sub> for this perturbed cell
-given its basal stata z<sup>(basal)</sup>.
+    Each response program $q$ in the learned response program matrix $w_{qk}$ aims to reveal a set of genes that are coherently activated or deactivated in perturbed cells. Translating $w_{qk}$ from latent space to gene expression space is achieved by sending $w_{qk}$ through CellCap's linear decoder.
+
+3. For a given perturbation, which cell states respond strongly via each response program?
+
+    For one perturbation $p$, given a response program $q$ of interest, the basal state $\vec{z}_{n}^\text{(basal)}$ can be queried by the learned perturbation key $\vec{\kappa}_{pq}$. This is a key question that CellCap addresses: the correspondence between basal cell state and perturbation response.
+
+4. What is the response amplitude of each response program in each basal cell state?
+
+    CellCap infers response amplitude "attention weights" $\beta_{nq}$ for each response program $q$ in each cell $n$ given its learned basal state $z_{nk}^\text{(basal)}$.
 
 Navigating this Repository
 --------------------------
@@ -47,10 +47,12 @@ The CellCap repository is organized as follows:
 ```
 <repo_root>/
 ├─ cellcap/               # CellCap python package
-├─ docs/                  # Package documentation, including notebooks for analyzing single-cell perturbation data with CellCap
+└─ docs/                  # Package documentation
+    └─ source/
+        └─ notebooks/     # Example jupyter notebooks
 ```
 
 Preprint and Citation
 --------------
 
-The preprint will be shortly posted to *bioRxiv*, and this section will be updated imminently.
+The preprint will be published shortly on *bioRxiv*, and the citation will be added here.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Understanding the correspondence between cellular identity and perturbation resp
 
 3. For a given perturbation, which cell states respond strongly via each response program?
 
-    For one perturbation $p$, given a response program $q$ of interest, the basal state $\vec{z}_{n}^\text{(basal)}$ can be queried by the learned perturbation key $\vec{\kappa}_{pq}$. This is a key question that CellCap addresses: the correspondence between basal cell state and perturbation response.
+    For one perturbation $p$, given a response program $q$ of interest, the basal state $\vec{z}_n^\text{(basal)}$ can be queried by the learned perturbation key $\vec{\kappa}_{pq}$. This is a key question that CellCap addresses: the correspondence between basal cell state and perturbation response.
 
 4. What is the response amplitude of each response program in each basal cell state?
 


### PR DESCRIPTION
Fix some issues with the readme.

Yang, in the future, use latex for all the math.  Do not use `<sub></sub>` html, because then it doesn't look like the latex in all the figures.

I think some of the explanations needed a little more work, in order to make them more like the explanations we wrote out in the paper.  I also worked on the grammar to make it easily readable, like the paper.